### PR TITLE
added in the UX metadata

### DIFF
--- a/porter.yaml
+++ b/porter.yaml
@@ -112,3 +112,52 @@ credentials:
 #    description: "Test cliend parameter."
 #    default: $AZURE_CLIENT_ID
 #    type: string
+
+# The following values are consumed by the Azure Portal and turned into visual blades and UI elements.
+custom:
+  com.azure.creatuidef:
+    blades:
+      Kubernetes:
+        displayOrder: 1
+        label: Kubernetes Properties
+      Azure:
+        displayOrder: 2
+        label: Azure Service Principals
+    elements:
+      - name: kubeconfig
+        tooltip: A valid Kubernetes config for the Kuberentes cluster to install Kubeflow
+        displayName: Kubernetes Configuration
+        displayOrder: 1
+        uitype: Microsoft.Common.TextBox
+        bladename: Kubernetes
+      - name: deploymentTime
+        hide: true
+      - name: cnab_installation_name
+        displayOrder: 1
+        tooltip: The CNAB Bundle installation name
+        displayName: Installation Name
+        bladename: Kubernetes
+      - name: SUBSCRIPTION_ID
+        tooltip: "The id for the Azure subscription to use"
+        displayName: Subscription ID
+        displayOrder: 2
+        uitype: Microsoft.Common.TextBox
+        bladename: Azure Service Principles
+      - name: CLIENT_ID
+        tooltip: "The Azure SP client or app id used by the Azure Service Operator"
+        displayName: Client or app ID
+        displayOrder: 2
+        uitype: Microsoft.Common.TextBox
+        bladename: Azure Service Principles
+      - name: TENANT_ID
+        tooltip: "The Azure tenant id used by the Azure Service Operator"
+        displayName: Azure tenant ID
+        displayOrder: 2
+        uitype: Microsoft.Common.TextBox
+        bladename: Azure Service Principles        
+      - name: CLIENT_SECRET
+        tooltip: "The Azure SP client secret or password used by the Azure Service Operator"
+        displayName: Azure client secret
+        displayOrder: 2
+        uitype: Microsoft.Common.TextBox
+        bladename: Azure Service Principles        


### PR DESCRIPTION
Requires a GH token created with push access to registry and stashed in a secret called GHCR_PASSWORD. 